### PR TITLE
Stacker now works properly (multiple files into one)

### DIFF
--- a/TheBlast Updated/LSW/tools/stacker/stacker.h
+++ b/TheBlast Updated/LSW/tools/stacker/stacker.h
@@ -10,6 +10,8 @@ namespace LSW {
 	namespace v2 {
 		namespace Stacker {
 
+			const size_t stack_size_default = 4096;
+
 			struct _stack_assist {
 				std::string filename;
 				__int64 siz_o_file = 0;


### PR DESCRIPTION
Stacker is a thing I am working on to make it possible to download one single file and extract it faster than anything (maybe later I could try zip format)

Example (adapted, because its folder is not called imported_stacker, and I had to copy it to another folder and relink dirent.h from _external somewhere else in stacker.h. That's it.):
```cpp
#include "imported_stacker\stacker.h"
#include <iostream>

using namespace LSW::v2;

int main()
{
	Stacker::compactor comp;
	Stacker::extractor extr;

	std::cout << "Add files:\n";

	comp.setOut("out.lohkf");

	for (bool keep = true; keep;)
	{
		std::string buf;
		std::getline(std::cin, buf);

		if (buf != "exit")
		{
			try {
				comp.insert(buf);
			}
			catch (std::string e)
			{
				std::cout << "\nAn error has occurred: " << e << std::endl;
				continue;
			}
		}
		else {
			keep = false;
		}
	}

	std::cout << "Compacting the file..." << std::endl;

	comp.compactAll();

	std::cout << "Enter \"ready\" when ready to extract test." << std::endl;

	for (bool keep = true; keep;)
	{
		std::string buf;
		std::cin >> buf;
		if (buf == "ready") keep = false;
	}

	try {
		extr.interpret("out.lohkf");
	}
	catch (std::string e)
	{
		std::cout << "\nAn error has occurred: " << e << std::endl;
		std::string buf;
		std::cin >> buf;
		return 0;
	}

	std::cout << "Extracting files..." << std::endl;

	try {
		extr.extractAll();
	}
	catch (std::string e)
	{
		std::cout << "\nAn error has occurred: " << e << std::endl;
		std::string buf;
		std::cin >> buf;
		return 0;
	}

	std::cout << "END!" << std::endl;


	std::string buf;
	std::cin >> buf;
}
```